### PR TITLE
Add support for CXF 2.7.x.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>com.google.code.inject</groupId>
 	<artifactId>guice-cxf</artifactId>
-	<version>0.2-SNAPSHOT</version>   
+	<version>0.3-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	
   <url>https://github.com/jakub-bochenski/guice-cxf</url>
@@ -69,8 +69,15 @@
 		<dependency>
 			<groupId>org.apache.cxf</groupId>
 			<artifactId>cxf-rt-frontend-jaxrs</artifactId>
-			<version>2.5.2</version>
-		</dependency> 
+			<version>2.7.18</version>
+		</dependency>
+
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.12</version>
+			<scope>test</scope>
+		</dependency>
 
 	</dependencies>
 </project>

--- a/src/main/java/com/google/code/inject/jaxrs/CXFClientModule.java
+++ b/src/main/java/com/google/code/inject/jaxrs/CXFClientModule.java
@@ -54,7 +54,7 @@ import com.google.inject.binder.ScopedBindingBuilder;
 import com.google.inject.multibindings.Multibinder;
 import com.google.inject.name.Names;
 import java.rmi.ServerException;
-import org.apache.cxf.jaxrs.client.ClientWebApplicationException;
+import javax.ws.rs.client.ClientException;
 
 public abstract class CXFClientModule implements Module {
 
@@ -127,7 +127,7 @@ public abstract class CXFClientModule implements Module {
 				} catch (final InvocationTargetException e) {
 					throw e.getCause();
 				}
-			} catch (final ClientWebApplicationException e) {
+			} catch (final ClientException e) {
 				final Class<?>[] types = method.getExceptionTypes();
 				for (final Class<?> type : types) {
 					final Throwable cause = e.getCause();

--- a/src/main/java/com/google/code/inject/jaxrs/util/Matchers.java
+++ b/src/main/java/com/google/code/inject/jaxrs/util/Matchers.java
@@ -49,14 +49,14 @@ public final class Matchers {
 			@Override
 			public boolean matches(Method m) {
 				return isResourceMethod(m)
-						&& getAnnotatedMethod(m).getAnnotation(annotation) != null;
+						&& getAnnotatedMethod(m.getDeclaringClass(), m).getAnnotation(annotation) != null;
 
 			}
 		};
 	}
 
 	private static boolean isResourceMethod(Method m) {
-		final Method annotatedMethod = getAnnotatedMethod(m);
+		final Method annotatedMethod = getAnnotatedMethod(m.getDeclaringClass(), m);
 
 		final int mod = m.getModifiers();
 		if (!isPublic(mod) || isStatic(mod))

--- a/src/test/java/com/google/code/inject/jaxrs/util/MatchersTest.java
+++ b/src/test/java/com/google/code/inject/jaxrs/util/MatchersTest.java
@@ -1,0 +1,71 @@
+package com.google.code.inject.jaxrs.util;
+
+import com.google.inject.matcher.Matcher;
+import org.junit.Test;
+
+import javax.ws.rs.Path;
+import java.lang.reflect.Method;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class MatchersTest {
+
+    @Test
+    public void testWithMethodWithNoAnnotation() throws Exception {
+        assertFalse(matches("methodA"));
+    }
+
+    @Test
+    public void testWithMethodWithPathAnnotation() throws Exception {
+        assertTrue(matches("methodB"));
+    }
+
+    @Test
+    public void testWithPrivateMethodWithPathAnnotation() throws Exception {
+        assertFalse(matches("methodC"));
+    }
+
+    @Test
+    public void testWithStaticMethodWithPathAnnotation() throws Exception {
+        assertFalse(matches("methodD"));
+    }
+
+    @Test
+    public void testWithInheritedMethodWithPathAnnotation() throws Exception {
+        assertTrue(matches("methodE"));
+    }
+
+    private boolean matches(String methodName) throws Exception {
+        Matcher<Method> matcher = Matchers.resourceMethod();
+        Method method = TestClass.class.getDeclaredMethod(methodName);
+        return matcher.matches(method);
+    }
+
+    private static class TestClass implements TestService {
+        public void methodA() {
+        }
+
+        @Path("/some-service")
+        public void methodB() {
+        }
+
+        @Path("/some-service")
+        private void methodC() {
+        }
+
+        @Path("/some-service")
+        public static void methodD() {
+        }
+
+        @Override
+        public void methodE() {
+        }
+    }
+
+    private interface TestService {
+        @Path("/some-service")
+        void methodE();
+    }
+
+}


### PR DESCRIPTION
In CXF 2.7.x, `org.apache.cxf.jaxrs.client.ClientWebApplicationException`
was replaced by `javax.ws.rs.client.ClientException` (see the _API
changes_ section in https://cxf.apache.org/docs/27-migration-guide.html).

In CXF 2.7.14+, the signature of `AnnotationUtils.getAnnotatedMethod()`
was changed to address CXF-6078. See the issue
https://issues.apache.org/jira/browse/CXF-6078 and the commit
https://github.com/apache/cxf/commit/30390cc755f58eab3b346dc7b035e6286d6662b8.
